### PR TITLE
Fill in `LocalIP` and add `ApiBaseUrl` to `manifest.ContentContext` for HTTP/TFTP templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ mounts:
     appendSuffix: true
 
   - path: /install.ipxe
-    # The templating context provides access to: .LocalIP, .RemoteIP, .HttpBaseUrl and .Manifest.
+    # The templating context provides access to: .LocalIP, .RemoteIP, .HttpBaseUrl, .ApiBaseUrl and .Manifest.
     # Sprig functions are available: masterminds.github.io/sprig
     content: |
       #!ipxe

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -76,6 +76,7 @@ var serverCmd = &cobra.Command{
 			_ = store.LoadFromDirectory(viper.GetString("manifestPath"))
 		}
 		store.GlobalHints.HttpPort = viper.GetInt("http.port")
+		store.GlobalHints.ApiPort = viper.GetInt("api.port")
 
 		// DHCP
 		dhcpServer, err := dhcpd.NewServer(viper.GetString("address"), viper.GetString("interface"), store)

--- a/manifest/schema.go
+++ b/manifest/schema.go
@@ -103,6 +103,8 @@ type ContentContext struct {
 	RemoteIP net.IP
 	// Base URL to the HTTP service (IP and port) - not API
 	HttpBaseUrl *url.URL
+	// Base URL to the API service (IP and port)
+	ApiBaseUrl *url.URL
 	// Copy of Manifest
 	Manifest *Manifest
 }

--- a/store/store.go
+++ b/store/store.go
@@ -36,6 +36,7 @@ type Store struct {
 	// sort of global config
 	GlobalHints struct {
 		HttpPort int
+		ApiPort  int
 	}
 }
 

--- a/tftpd/handler.go
+++ b/tftpd/handler.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -139,7 +141,11 @@ func (server *Server) tftpReadHandler(filename string, rf io.ReaderFrom) error {
 			RemoteIP: raddr.IP,
 			HttpBaseUrl: &url.URL{
 				Scheme: "http",
-				Host:   fmt.Sprintf("%s:%d", laddr.String(), server.store.GlobalHints.HttpPort),
+				Host:   net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.GlobalHints.HttpPort)),
+			},
+			ApiBaseUrl: &url.URL{
+				Scheme: "http",
+				Host:   net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.GlobalHints.ApiPort)),
 			},
 			Manifest: manifest,
 		})


### PR DESCRIPTION
This project is awesome, thank you for making it!

I noticed that the `LocalIP` field of `manifest.ContentContext` was not filled in when evaluating HTTP templates, so I fixed that.  I also added an `ApiBaseUrl` field, so that templates can more easily construct `netbootd` API requests, for example to have a Kickstart script hit the `/api/self/suspend-boot` endpoint in a `%post` script via `curl {{ .ApiBaseUrl }}/api/self/suspend-boot` when installation has finished successfully.