### PR TITLE
Add `Vars` map to `manifest.Manifest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ ipxe: true
 # which netbootd automatically points to be itself.
 # This should map to a "mount" below.
 bootFilename: install.ipxe
+# Arbitrary mapping of key/value pairs that can be substituted
+# in mount content templates below using {{ .Manifest.Vars.xxx }}
+vars:
+  gfxpayload: 800x600x16,800x600
+  auto: true
 
 # Mounts define virtual per-host (per-manifest) paths that are acessible
 # over both TFTP and HTTP but only from the IP address of in this manifest.
@@ -133,7 +138,7 @@ mounts:
       set base {{ .HttpBaseUrl }}/netboot
 
       {{ $hostnameParts := splitList "." .Manifest.Hostname }}
-      kernel ${base}/linux gfxpayload=800x600x16,800x600 initrd=initrd.gz auto=true url={{ .HttpBaseUrl.String }}/preseed.txt netcfg/get_ipaddress={{ .Manifest.IPv4.IP }} netcfg/get_netmask={{ .Manifest.IPv4.Netmask }} netcfg/get_gateway={{ first .Manifest.Router }} netcfg/get_nameservers="{{ .Manifest.DNS | join " " }}" netcfg/disable_autoconfig=true hostname={{ first $hostnameParts }} domain={{ rest $hostnameParts | join "." }} DEBCONF_DEBUG=developer
+      kernel ${base}/linux gfxpayload={{ .Manifest.Vars.gfxpayload }} initrd=initrd.gz auto={{ .Manifest.Vars.auto }} url={{ .HttpBaseUrl.String }}/preseed.txt netcfg/get_ipaddress={{ .Manifest.IPv4.IP }} netcfg/get_netmask={{ .Manifest.IPv4.Netmask }} netcfg/get_gateway={{ first .Manifest.Router }} netcfg/get_nameservers="{{ .Manifest.DNS | join " " }}" netcfg/disable_autoconfig=true hostname={{ first $hostnameParts }} domain={{ rest $hostnameParts | join "." }} DEBCONF_DEBUG=developer
       initrd ${base}/initrd.gz
       boot
 ```

--- a/manifest/schema.go
+++ b/manifest/schema.go
@@ -27,6 +27,7 @@ type Manifest struct {
 	BootFilename  string `yaml:"bootFilename"`
 	Mounts        []Mount
 	Suspended     bool
+	Vars          map[string]interface{}
 }
 
 // Mount represents a path exposed via TFTP and HTTP.


### PR DESCRIPTION
Add new `Vars` map to `manifest.Manifest` which can store arbitrary key/value pairs to aide in programmatically creating manifests from a template.  For example, given the following manifest template `manifest.yml.template`:

```yaml
---
id: rocky9.5
ipv4: REPLACE_ME
leaseDuration: 1h
mac:
  - REPLACE_ME
dns:
  - REPLACE_ME
router:
  - REPLACE_ME
ntp:
  - REPLACE_ME
ipxe: true
bootFilename: install.ipxe
vars:
  rootpw: "REPLACE_ME"
  nwidgerpw: "REPLACE_ME"
  sshkey: "REPLACE_ME"
mounts:
  - path: /repo
    pathIsPrefix: true
    proxy: https://dl.rockylinux.org/vault/rocky/9.5
    appendSuffix: true

  - path: /ks
    content: |
      text

      %addon com_redhat_kdump --enable --reserve-mb='auto'

      %end

      keyboard --xlayouts='us'
      lang en_US.UTF-8
      network --bootproto=dhcp --device=link

      %packages
      @^server-product-environment

      %end

      firstboot --disable
      skipx

      ignoredisk --only-use=sda
      autopart
      clearpart --all --initlabel

      timezone America/New_York --utc

      rootpw --iscrypted --allow-ssh {{ .Manifest.Vars.rootpw }}
      user --groups=wheel --name=nwidger --password={{ .Manifest.Vars.nwidgerpw }} --iscrypted --gecos="nwidger"
      sshkey --username=nwidger "{{ .Manifest.Vars.sshkey }}"

      %post --interpreter=/bin/bash --erroronfail

      curl --fail-with-body '{{ .ApiBaseUrl }}/api/self/suspend-boot'

      %end

      reboot --eject

  - path: /install.ipxe
    content: |
      #!ipxe

      set base-repo {{ .HttpBaseUrl }}/repo
      set base-ks {{ .HttpBaseUrl }}/ks

      kernel ${base-repo}/BaseOS/x86_64/os/images/pxeboot/vmlinuz initrd=initrd.img inst.stage2=${base-repo}/BaseOS/x86_64/os inst.ks=${base-ks} inst.repo=${base-repo}/BaseOS/x86_64/os
      initrd ${base-repo}/BaseOS/x86_64/os/images/pxeboot/initrd.img
      boot
```

we can generate an actual manifest from the template using a tool like `yq` (https://mikefarah.gitbook.io/yq/):

```bash
cp manifest.yml.template manifest.yml
yq -i 'ipv4 = "192.168.2.2/24"' manifest.yml
yq -i 'mac[0] = "12:23:34:45:56:67"' manifest.yml
yq -i 'dns[0] = "192.168.2.1"' manifest.yml
yq -i 'router[0] = "192.168.2.1"' manifest.yml
yq -i 'ntp[0] = "192.168.2.1"' manifest.yml
yq -i 'vars.rootpw = "<password>"' manifest.yml
yq -i 'vars.nwidgerpw = "<password>"' manifest.yml
yq -i 'vars.sshkey = "<ssh-key>"' manifest.yml
```

We can then use `{{ .Manifest.Vars.xxx }}` within templates, such as the `/ks` kickstarter mount, to customize what is returned.  Without `Vars`, we'd need to do something like add placeholders such as `<ROOTPW>` in the Kickstarter file and then run `sed` over `manifest.yml` to substitute the values, which seems less clean.

Obviously this is just one way to solve this problem, please let me know if you think this is terrible or think there's a better way. Thanks!