### PR TITLE
Add options for JSON logger and no color console logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Flags:
 Global Flags:
   -d, --debug                    enable debug logging
       --disable-journal-logger   disable zerolog journald logger
+      --enable-json-logger       enable JSON logging
+      --no-color                 disable colored logging
       --trace                    enable trace logging
 ```
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,8 +25,14 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&trace, "trace", false, "enable trace logging")
 	viper.BindPFlag("trace", rootCmd.Flags().Lookup("trace"))
 
-	rootCmd.PersistentFlags().BoolVar(&config.ZeroLogJournalDEnabled, "disable-journal-logger", false, "disable zerolog journald logger")
+	rootCmd.PersistentFlags().BoolVar(&config.ZeroLogJournalDDisabled, "disable-journal-logger", false, "disable zerolog journald logger")
 	viper.BindPFlag("disable-journal-logger", rootCmd.Flags().Lookup("disable-journal-logger"))
+
+	rootCmd.PersistentFlags().BoolVar(&config.ZeroLogNoColor, "no-color", false, "disable colored logging")
+	viper.BindPFlag("no-color", rootCmd.Flags().Lookup("no-color"))
+
+	rootCmd.PersistentFlags().BoolVar(&config.ZeroLogEnableJSONLogger, "enable-json-logger", false, "enable JSON logging")
+	viper.BindPFlag("enable-json-logger", rootCmd.Flags().Lookup("enable-json-logger"))
 }
 
 var rootCmd = &cobra.Command{

--- a/config/zerolog.go
+++ b/config/zerolog.go
@@ -10,8 +10,10 @@ import (
 )
 
 var (
-	zerologInitDone        bool // to prevent zerolog to be initialized twice in specific situations (like parsing error of viper configuration file)
-	ZeroLogJournalDEnabled bool // used by viper to store the status of the --disable-journal-logger flag
+	zerologInitDone         bool // to prevent zerolog to be initialized twice in specific situations (like parsing error of viper configuration file)
+	ZeroLogJournalDDisabled bool // used by viper to store the status of the --disable-journal-logger flag
+	ZeroLogNoColor          bool // used by viper to store the status of the --no-color flag
+	ZeroLogEnableJSONLogger bool // used by viper to store the status of the --enable-json-logger flag
 )
 
 func init() {
@@ -23,12 +25,17 @@ func init() {
 
 func InitZeroLog() {
 	if !zerologInitDone {
-		if ZeroLogJournalDEnabled {
-			log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+		var output io.Writer
+		output = os.Stderr
+		if !ZeroLogEnableJSONLogger {
+			output = zerolog.ConsoleWriter{Out: os.Stderr, NoColor: ZeroLogNoColor}
+		}
+		if ZeroLogJournalDDisabled {
+			log.Logger = log.Output(output)
 			log.Debug().Msg("Enabled console writer")
 		} else {
 			journalWriter := journald.NewJournalDWriter()
-			multi := io.MultiWriter(zerolog.ConsoleWriter{Out: os.Stderr}, journalWriter)
+			multi := io.MultiWriter(output, journalWriter)
 			log.Logger = log.Output(multi)
 			log.Debug().Msg("Enabled journald writer")
 		}


### PR DESCRIPTION
Add new global flag `--enable-json-logger` to enable JSON logs.  When JSON logs aren't enabled, `--no-color` can be given to disable ANSI colors in the console output.