### PR TITLE
Allow relative `path.localDir` paths when new `--root` flag is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Flags:
   -p, --http-port int         HTTP port to listen on (default 8080)
   -i, --interface string      interface to listen on, e.g. eth0 (DHCP)
   -m, --manifests string      load manifests from directory
+      --root string           if not given as an absolute path, a mount's path.localDir is relative to this directory
 
 Global Flags:
   -d, --debug                    enable debug logging

--- a/api/server.go
+++ b/api/server.go
@@ -26,7 +26,7 @@ type Server struct {
 
 // NewServer set up HTTP API server instance
 // If authorization is passed, requires privileged operation callers to present Authorization header with this content.
-func NewServer(store *store.Store, authorization string) (server *Server, err error) {
+func NewServer(store *store.Store, authorization, rootPath string) (server *Server, err error) {
 	r := mux.NewRouter()
 
 	server = &Server{
@@ -119,13 +119,13 @@ func NewServer(store *store.Store, authorization string) (server *Server, err er
 		buf, _ := ioutil.ReadAll(r.Body)
 		var m manifest.Manifest
 		if r.Header.Get("Content-Type") == "application/json" {
-			err = json.Unmarshal(buf, &m)
+			m, err = manifest.ManifestFromJson(buf, rootPath)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
 		} else {
-			m, err = manifest.ManifestFromYaml(buf)
+			m, err = manifest.ManifestFromYaml(buf, rootPath)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
@@ -176,13 +175,9 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rp.ServeHTTP(w, r)
 		return
 	} else if mount.LocalDir != "" {
-		path := filepath.Join(mount.LocalDir, mount.Path)
+		path := mount.HostPath(h.server.rootPath, r.URL.Path)
 
-		if mount.AppendSuffix {
-			path = filepath.Join(mount.LocalDir, strings.TrimPrefix(r.URL.Path, mount.Path))
-		}
-
-		if !strings.HasPrefix(path, mount.LocalDir) {
+		if !mount.ValidateHostPath(h.server.rootPath, path) {
 			h.server.logger.Error().
 				Err(err).
 				Msgf("Requested path is invalid: %q", path)

--- a/httpd/server.go
+++ b/httpd/server.go
@@ -14,11 +14,12 @@ type Server struct {
 	httpClient *http.Client
 	httpServer *http.Server
 
-	logger zerolog.Logger
-	store  *store.Store
+	logger   zerolog.Logger
+	store    *store.Store
+	rootPath string
 }
 
-func NewServer(store *store.Store) (server *Server, err error) {
+func NewServer(store *store.Store, rootPath string) (server *Server, err error) {
 
 	server = &Server{
 		httpServer: &http.Server{
@@ -26,8 +27,9 @@ func NewServer(store *store.Store) (server *Server, err error) {
 			MaxHeaderBytes: 1 << 20,
 			IdleTimeout:    10 * time.Second,
 		},
-		logger: log.With().Str("service", "http").Logger(),
-		store:  store,
+		logger:   log.With().Str("service", "http").Logger(),
+		store:    store,
+		rootPath: rootPath,
 	}
 
 	server.httpServer.Handler = Handler{server: server}

--- a/manifest/io.go
+++ b/manifest/io.go
@@ -8,33 +8,33 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func ManifestFromJson(content []byte) (manifest Manifest, err error) {
+func ManifestFromJson(content []byte, rootPath string) (manifest Manifest, err error) {
 	err = json.Unmarshal(content, &manifest)
 	if err != nil {
 		return manifest, err
 	}
 
-	return manifest, manifest.Validate()
+	return manifest, manifest.Validate(rootPath)
 }
 
 func (m *Manifest) ToJson() ([]byte, error) {
 	return json.MarshalIndent(m, "", "  ")
 }
 
-func ManifestFromYaml(content []byte) (manifest Manifest, err error) {
+func ManifestFromYaml(content []byte, rootPath string) (manifest Manifest, err error) {
 	err = yaml.Unmarshal(content, &manifest)
 	if err != nil {
 		return manifest, err
 	}
 
-	return manifest, manifest.Validate()
+	return manifest, manifest.Validate(rootPath)
 }
 
-func (m Manifest) Validate() error {
+func (m Manifest) Validate(rootPath string) error {
 	for _, mount := range m.Mounts {
 		if mount.LocalDir != "" {
-			if !filepath.IsAbs(mount.LocalDir) {
-				return fmt.Errorf("localDir needs to be absolute path")
+			if !filepath.IsAbs(mount.LocalDir) && rootPath == "" {
+				return fmt.Errorf("localDir needs to be absolute path when rootPath is not set")
 			}
 		}
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -53,7 +53,7 @@ func NewStore(cfg Config) (*Store, error) {
 	return &store, nil
 }
 
-func (s *Store) LoadFromDirectory(path string) (err error) {
+func (s *Store) LoadFromDirectory(path, rootPath string) (err error) {
 	items, err := os.ReadDir(path)
 	for _, item := range items {
 		if !item.Type().IsRegular() ||
@@ -68,7 +68,7 @@ func (s *Store) LoadFromDirectory(path string) (err error) {
 				Msg("cannot open file")
 			continue
 		}
-		m, err := manifest.ManifestFromYaml(b)
+		m, err := manifest.ManifestFromYaml(b, rootPath)
 		if err != nil {
 			s.logger.Error().
 				Err(err).

--- a/tftpd/handler.go
+++ b/tftpd/handler.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
@@ -172,13 +171,9 @@ func (server *Server) tftpReadHandler(filename string, rf io.ReaderFrom) error {
 			Int64("sent", n).
 			Msg("transfer finished")
 	} else if mount.LocalDir != "" {
-		path := filepath.Join(mount.LocalDir, mount.Path)
+		path := mount.HostPath(server.rootPath, filename)
 
-		if mount.AppendSuffix {
-			path = filepath.Join(mount.LocalDir, strings.TrimPrefix(filename, mount.Path))
-		}
-
-		if !strings.HasPrefix(path, mount.LocalDir) {
+		if !mount.ValidateHostPath(server.rootPath, path) {
 			err := fmt.Errorf("requested path is invalid")
 			server.logger.Error().
 				Err(err).

--- a/tftpd/server.go
+++ b/tftpd/server.go
@@ -14,16 +14,18 @@ type Server struct {
 	httpClient *http.Client
 	tftpServer *tftp.Server
 
-	logger zerolog.Logger
-	store  *store.Store
+	logger   zerolog.Logger
+	store    *store.Store
+	rootPath string
 }
 
-func NewServer(store *store.Store) (server *Server, err error) {
+func NewServer(store *store.Store, rootPath string) (server *Server, err error) {
 
 	server = &Server{
 		httpClient: &http.Client{},
 		logger:     log.With().Str("service", "tftp").Logger(),
 		store:      store,
+		rootPath:   rootPath,
 	}
 
 	return server, nil


### PR DESCRIPTION
Add new `--root <path>` flag to `netbootd server` command which defines the path from which mount `path.localDir` values should be relative if they are not given as absolute paths.

Fixes #24.