### PR TITLE
Add more error checking

### DIFF
--- a/cmd/arpinject.go
+++ b/cmd/arpinject.go
@@ -28,6 +28,9 @@ var arpInjectCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		config.InitZeroLog()
 		parsedIp := net.ParseIP(ip)
+		if parsedIp == nil {
+			log.Fatal().Msgf("invalid ip: %s", ip)
+		}
 		parsedMac, err := net.ParseMAC(mac)
 		if err != nil {
 			log.Error().

--- a/dhcpd/server.go
+++ b/dhcpd/server.go
@@ -3,6 +3,7 @@
 package dhcpd
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/DSpeichert/netbootd/store"
@@ -22,9 +23,17 @@ type Server struct {
 }
 
 func NewServer(addr, ifname string, store *store.Store) (server *Server, err error) {
+	var ip net.IP
+	// only parse addr if non-zero length
+	if addr != "" {
+		ip = net.ParseIP(addr)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid ip: %s", addr)
+		}
+	}
 	server = &Server{
 		address: &net.UDPAddr{
-			IP:   net.ParseIP(addr),
+			IP:   ip,
 			Port: 67,
 			Zone: ifname,
 		},

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -73,6 +73,10 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	spoofIPs, ok := r.URL.Query()["spoof"]
 	if ok && len(spoofIPs[0]) > 0 {
 		manifestRaddr = net.ParseIP(spoofIPs[0])
+		if manifestRaddr == nil {
+			http.Error(w, "unable to determine host address: invalid ip: "+spoofIPs[0], http.StatusBadRequest)
+			return
+		}
 	}
 
 	manifest := h.server.store.FindByIP(manifestRaddr)


### PR DESCRIPTION
Mostly checking previously ignored `error` values and a `nil` returned by `net.ParseIP`.  Only tricky bit is not parsing IP address string parameters unless they are non-zero length in certain cases.  This is necessary since an empty string is used in certain situations to mean "do a wildcard bind" rather than "bind to this address".