### PR TITLE
Fixes bug in TFTP host path logic where prefix is not being removed

### DIFF
--- a/manifest/schema.go
+++ b/manifest/schema.go
@@ -69,6 +69,10 @@ func (m Mount) hostPathPrefix(rootPath string) string {
 func (m Mount) HostPath(rootPath, requestPath string) string {
 	path := m.Path
 	if m.AppendSuffix {
+		if !strings.HasPrefix(requestPath, "/") {
+			requestPath = "/"+requestPath
+		}
+
 		path = strings.TrimPrefix(requestPath, m.Path)
 	}
 	return filepath.Join(m.hostPathPrefix(rootPath), path)


### PR DESCRIPTION
I observed a bug when serving contents from a `localDir` over TFTP. When you request content through TFTP through a mount with `pathIsPrefix` and `appendSuffix` as true, the `path` of the mount appears twice. You can see this in the error log for the request.

Mount:
```yaml
  - path: /examples
    pathIsPrefix: true
    localDir: /etc/netbootd/examples/
    appendSuffix: true
```

Request
```bash
curl -s tftp://127.0.0.1/examples/ubuntu-2004.yml -o /dev/null
```

Log:
```
3:55AM INF new TFTP request client=127.0.0.1 path=examples/ubuntu-2004.yml service=tftp
3:55AM TRC found mount mount={"AppendSuffix":true,"Content":"","LocalDir":"/etc/netbootd/examples/","Path":"/examples","PathIsPrefix":true,"Proxy":""} service=tftp
3:55AM TRC Figuring out paths hostPath=/etc/netbootd/examples/examples/ubuntu-2004.yml m.Path=/examples requestpath=examples/ubuntu-2004.yml service=tftp
3:55AM ERR Could not get file from local dir: "examples/ubuntu-2004.yml" error="open /etc/netbootd/examples/examples/ubuntu-2004.yml: no such file or directory" service=tftp
```

I added some extra logging and it looks like in `m.HostPath`, the `requestPath` parameter does not have a "/" prefix for `strings.TrimPrefix` to remove `m.Path` from the `requestPath` correctly.

```
3:55AM TRC Figuring out paths hostPath=/etc/netbootd/examples/examples/ubuntu-2004.yml m.Path=/examples requestpath=examples/ubuntu-2004.yml service=tftp
```

I'm not sure if other parts of `server.tftpReadHandler` suffer from this silent bug, but this PR fixes this specific issue and makes sure that content can be served over TFTP and HTTP using the same mount configuration.