### PR TITLE
Implementing store persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Run e.g. `./netbootd --trace server -m ./examples/`
 ## Roadmap / TODOs
 
 * [x] API TLS & Authentication
-* [ ] Manifest persistence (currently API-configured manifests live in memory only)
+* [x] Manifest persistence (currently API-configured manifests live in memory only)
 * [ ] Pluggable store backends (e.g. Redis, Etcd, files) for Manifests
 * [ ] Notifications (e.g. long-polling wait to return when a given host actually booted)
 * [ ] Per-manifest logs available over API

--- a/api/server.go
+++ b/api/server.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -124,7 +124,7 @@ func NewServer(store *store.Store, authorization, rootPath string) (server *Serv
 			return
 		}
 
-		buf, _ := ioutil.ReadAll(r.Body)
+		buf, _ := io.ReadAll(r.Body)
 		var m manifest.Manifest
 		if r.Header.Get("Content-Type") == "application/json" {
 			m, err = manifest.ManifestFromJson(buf, rootPath)
@@ -139,9 +139,10 @@ func NewServer(store *store.Store, authorization, rootPath string) (server *Serv
 				return
 			}
 		}
-		err = store.PutManifest(m)
+
+		err = store.PutManifest(&m)
 		if err != nil {
-			http.Error(w, "error storing manifest: "+err.Error(), http.StatusBadRequest)
+			http.Error(w, "error storing manifest: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
@@ -155,7 +156,10 @@ func NewServer(store *store.Store, authorization, rootPath string) (server *Serv
 		}
 
 		vars := mux.Vars(r)
-		store.ForgetManifest(vars["id"])
+		if err := store.ForgetManifest(vars["id"]); err != nil {
+			http.Error(w, "error forgetting manifest: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 
 		w.WriteHeader(http.StatusNoContent)
 	}).Methods("DELETE")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+	"io/fs"
 	"net"
 	"os"
 	"os/signal"
@@ -20,15 +22,16 @@ import (
 )
 
 var (
-	addr         string
-	ifname       string
-	httpPort     int
-	syslogPort   int
-	apiPort      int
-	apiTlsCert   string
-	apiTlsKey    string
-	manifestPath string
-	rootPath     string
+	addr         	string
+	ifname       	string
+	httpPort     	int
+	syslogPort   	int
+	apiPort      	int
+	apiTlsCert   	string
+	apiTlsKey    	string
+	manifestPath 	string
+	persistencePath string
+	rootPath     	string
 )
 
 func init() {
@@ -53,8 +56,11 @@ func init() {
 	serverCmd.Flags().StringVarP(&ifname, "interface", "i", "", "interface to listen on, e.g. eth0 (DHCP)")
 	viper.BindPFlag("interface", serverCmd.Flags().Lookup("interface"))
 
-	serverCmd.Flags().StringVarP(&manifestPath, "manifests", "m", "", "load manifests from directory")
-	viper.BindPFlag("manifestPath", serverCmd.Flags().Lookup("manifests"))
+	serverCmd.Flags().StringVarP(&manifestPath, "manifestPath", "m", "", "Load manifests from directory")
+	viper.BindPFlag("store.manifestPath", serverCmd.Flags().Lookup("manifestPath"))
+
+	serverCmd.Flags().StringVarP(&persistencePath, "persistencePath", "v", "", "Directory to persist HTTP API configured manifests")
+	viper.BindPFlag("store.persistencePath", serverCmd.Flags().Lookup("persistencePath"))
 
 	serverCmd.Flags().StringVarP(&rootPath, "root", "", "", "if not given as an absolute path, a mount's path.localDir is relative to this directory")
 	viper.BindPFlag("rootPath", serverCmd.Flags().Lookup("root"))
@@ -75,18 +81,27 @@ var serverCmd = &cobra.Command{
 			zerolog.SetGlobalLevel(zerolog.InfoLevel)
 		}
 
+		manifestPath := viper.GetString("store.manifestPath")
+		checkDirExists(manifestPath, false)
+
+		persistencePath := viper.GetString("store.persistencePath")
+		checkDirExists(persistencePath, true)
+
 		// set up store
-		store, _ := store.NewStore(store.Config{
-			// TODO: config
-			PersistenceDirectory: "",
+		store, err := store.NewStore(store.Config{
+			PersistenceDirectory: persistencePath,
 		})
-		if viper.GetString("manifestPath") != "" {
-			log.Info().Str("path", viper.GetString("manifestPath")).Msg("Loading manifests")
-			err := store.LoadFromDirectory(viper.GetString("manifestPath"), viper.GetString("rootPath"))
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to load manifests")
-			}
+
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to create store")
 		}
+
+		log.Info().Str("path", manifestPath).Msg("Loading manifests")
+		err = store.LoadFromDirectory(manifestPath, viper.GetString("rootPath"))
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to load manifests")
+		}
+
 		store.GlobalHints.HttpPort = viper.GetInt("http.port")
 		store.GlobalHints.SyslogPort = viper.GetInt("syslog.port")
 		store.GlobalHints.ApiPort = viper.GetInt("api.port")
@@ -198,4 +213,24 @@ var serverCmd = &cobra.Command{
 		signal.Notify(sigs, os.Interrupt)
 		<-sigs
 	},
+}
+
+func checkDirExists(path string, fatal bool) {
+	info, err := os.Stat(path);
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			log.Fatal().Err(err).Str("path", path).Msg("Path does not exist")
+		}
+
+		log.Fatal().Err(err).Str("path", path).Msg("Failed to stat path")
+	}
+
+	// make sure that path points to a directory, throw fatal if it does not
+	if !info.Mode().IsDir() {
+		if fatal {
+			log.Fatal().Err(err).Str("path", path).Msg("Path must be a directory")
+		} else {
+			log.Error().Err(err).Str("path", path).Msg("Path must be a directory")
+		}
+	}
 }

--- a/config/viper.go
+++ b/config/viper.go
@@ -16,7 +16,8 @@ func InitConfig() {
 	viper.AddConfigPath("$HOME/.config/netbootd/")
 	viper.AddConfigPath(".")
 
-	viper.SetDefault("store.path", "/var/lib/netbootd")
+	viper.SetDefault("store.manifestPath", "/etc/netbootd/manifests/")
+	viper.SetDefault("store.persistencePath", "/var/lib/netbootd/manifests/")
 
 	viper.SetEnvPrefix("netbootd")
 	viper.AutomaticEnv()

--- a/manifest/io.go
+++ b/manifest/io.go
@@ -31,6 +31,14 @@ func ManifestFromYaml(content []byte, rootPath string) (manifest Manifest, err e
 }
 
 func (m Manifest) Validate(rootPath string) error {
+	if m.ID == "" {
+		return fmt.Errorf("ID cannot be null")
+	}
+
+	if len(m.IPv4.IP) == 0 {
+		return fmt.Errorf("no IPv4 address provided")
+	}
+
 	for _, mount := range m.Mounts {
 		if mount.LocalDir != "" {
 			if !filepath.IsAbs(mount.LocalDir) && rootPath == "" {

--- a/netbootd.yml
+++ b/netbootd.yml
@@ -30,4 +30,5 @@ http:
   port: 8080
 
 # Set to directory from which initial manifests will be loaded at startup
-#manifestPath: /etc/netbootd/manifests/
+# store:
+#   manifestPath: /etc/netbootd/manifests/

--- a/store/persistence.go
+++ b/store/persistence.go
@@ -1,15 +1,38 @@
 package store
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/DSpeichert/netbootd/manifest"
 )
 
-func (s *Store) putPersistentManifest(m manifest.Manifest) error {
+func (s *Store) putPersistentManifest(m *manifest.Manifest) error {
+	path := filepath.Join(s.config.PersistenceDirectory, filepath.Base(m.ID) + ".yml")
+
+	b, err := m.ToYaml()
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(path, b, 0644)
+	if err != nil {
+		return err
+	}
+
+	s.paths[m.ID] = path
 
 	return nil
 }
 
 func (s *Store) forgetPersistentManifest(id string) error {
+	path := s.paths[id]
+	delete(s.paths, id)
+
+	err := os.Remove(path)
+	if err != nil {
+		s.logger.Err(err).Str("path", path).Msg("Failed to remove manifest file.")
+	}
 
 	return nil
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -30,6 +29,9 @@ type Store struct {
 	// mapping Mac Address to Manifest
 	mac map[string]*manifest.Manifest
 
+	// mapping Manifest ID to store path
+	paths map[string]string
+
 	logger zerolog.Logger
 
 	mutex sync.RWMutex
@@ -48,6 +50,7 @@ func NewStore(cfg Config) (*Store, error) {
 		manifests: make(map[string]*manifest.Manifest),
 		ip:        make(map[string]*manifest.Manifest),
 		mac:       make(map[string]*manifest.Manifest),
+		paths: 	   make(map[string]string),
 		logger:    log.With().Str("module", "store").Logger(),
 	}
 
@@ -56,6 +59,13 @@ func NewStore(cfg Config) (*Store, error) {
 
 func (s *Store) LoadFromDirectory(path, rootPath string) (err error) {
 	items, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	for _, item := range items {
 		if !item.Type().IsRegular() ||
 			(!strings.HasSuffix(item.Name(), ".yml") && !strings.HasSuffix(item.Name(), ".yaml")) {
@@ -76,13 +86,16 @@ func (s *Store) LoadFromDirectory(path, rootPath string) (err error) {
 				Msg("cannot parse YAML manifest")
 			continue
 		}
-		err = s.PutManifest(m)
-		if err != nil {
-			s.logger.Error().
-				Err(err).
-				Msg("cannot add manifest to store")
-			continue
+
+		s.manifests[m.ID] = &m
+
+		s.ip[m.IPv4.IP.To16().String()] = &m
+
+		for _, mac := range m.MAC {
+			s.mac[mac.String()] = &m
 		}
+
+		s.paths[m.ID] = filepath.Join(path, item.Name())
 
 		if s.logger.Debug().Enabled() {
 			s.logger.Debug().
@@ -91,32 +104,21 @@ func (s *Store) LoadFromDirectory(path, rootPath string) (err error) {
 		}
 
 	}
-	return
+
+	return nil
 }
 
-func (s *Store) PutManifest(m manifest.Manifest) error {
-	if m.IPv4.IP == nil {
-		return errors.New("no IPv4 address provided")
-	}
-
-	if m.ID == "" {
-		return errors.New("ID cannot be null")
-	}
-
+func (s *Store) PutManifest(m *manifest.Manifest) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	s.manifests[m.ID] = &m
-	s.ip[string(m.IPv4.IP.To16())] = &m
+	s.manifests[m.ID] = m
+	s.ip[m.IPv4.IP.To16().String()] = m
 	for _, mac := range m.MAC {
-		s.mac[mac.String()] = &m
+		s.mac[mac.String()] = m
 	}
 
-	if s.config.PersistenceDirectory != "" {
-		return s.putPersistentManifest(m)
-	}
-
-	return nil
+	return s.putPersistentManifest(m)
 }
 
 func (s *Store) ForgetManifest(id string) error {
@@ -131,16 +133,12 @@ func (s *Store) ForgetManifest(id string) error {
 	defer s.mutex.Unlock()
 
 	delete(s.manifests, m.ID)
-	delete(s.ip, string(m.IPv4.IP.To16()))
+	delete(s.ip, m.IPv4.IP.To16().String())
 	for _, mac := range m.MAC {
 		delete(s.mac, mac.String())
 	}
 
-	if s.config.PersistenceDirectory != "" {
-		return s.forgetPersistentManifest(id)
-	}
-
-	return nil
+	return s.forgetPersistentManifest(id)
 }
 
 func (s *Store) Find(id string) *manifest.Manifest {
@@ -154,7 +152,7 @@ func (s *Store) FindByIP(ip net.IP) *manifest.Manifest {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.ip[string(ip.To16())]
+	return s.ip[ip.To16().String()]
 }
 
 func (s *Store) FindByMAC(mac net.HardwareAddr) *manifest.Manifest {


### PR DESCRIPTION
Implements store persistence only through disk.

For simplicity I set `store.PersistanceDirectory` automatically set to `manifestPath` from netbootd's configuration inputs (yaml, command line, etc.). I also made it so that `manifestPath`, when left empty, is always set to the default `store.path` in viper. This should allow manifests to be persisted in configurable and predictable locations.

I explicitly chose _not_ to have the `PersistanceDirectory` be a separate configuration than `manifestPath` since I can't immediately think of a benefit for this. Hypothetically you could prevent user-configured manifests from being deleted by storing API-managed manifests in a separate directory by using a separate path. I can implement that should the project require this.