### PR TITLE
HTTP server only accepts GET method

### DIFF
--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -64,6 +64,11 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	h.server.logger.Info().
 		Str("path", r.RequestURI).
 		Str("client", raddr.String()).


### PR DESCRIPTION
Small QOL change where the HTTP content server (not the API server) only works for GET methods. All other HTTP methods return an HTTP error status.