### PR TITLE
fix: normalize paths for TFTP/HTTP mount matching and suffix extraction

### DIFF
--- a/manifest/schema.go
+++ b/manifest/schema.go
@@ -11,15 +11,24 @@ import (
 	"time"
 )
 
-// normalizePath strips leading and trailing slashes to produce a canonical
-// path for comparison. This ensures "/foo/bar", "foo/bar", and "foo/bar/"
-// are all treated identically.
-func normalizePath(p string) string {
-	return strings.Trim(p, "/")
+// cleanPath resolves p into its canonical form for path matching and
+// joining: "." and ".." segments are resolved as if p were rooted (so ".."
+// can never climb above p's own root), repeated slashes collapse, and the
+// leading and trailing slashes are stripped. hadTrailingSlash reports
+// whether the non-empty cleaned path represents a directory-style request
+// (the input ended in "/"), which matters when the suffix is later appended
+// to a proxied URL or local path.
+func cleanPath(p string) (cleaned string, hadTrailingSlash bool) {
+	trailing := len(p) > 1 && strings.HasSuffix(p, "/")
+	c := strings.TrimPrefix(path.Clean("/"+p), "/")
+	if c == "." {
+		c = ""
+	}
+	return c, trailing && c != ""
 }
 
-// pathHasPrefix reports whether the normalized request path starts with the
-// normalized mount prefix at a path-segment boundary. An empty prefix matches
+// pathHasPrefix reports whether the cleaned request path starts with the
+// cleaned mount prefix at a path-segment boundary. An empty prefix matches
 // everything. This prevents "foo" from incorrectly matching "foobar".
 func pathHasPrefix(requestPath, prefix string) bool {
 	if prefix == "" {
@@ -30,6 +39,28 @@ func pathHasPrefix(requestPath, prefix string) bool {
 	}
 	// The request must continue with a "/" after the prefix.
 	return strings.HasPrefix(requestPath, prefix+"/")
+}
+
+// EscapePathSuffix percent-escapes each segment of a canonical, decoded path
+// suffix (as returned by Mount.PathSuffix) so it can be safely appended to a
+// proxy target URL via (*url.URL).JoinPath. JoinPath treats its arguments as
+// already-escaped URL syntax, so passing a raw suffix through unescaped risks
+// either corrupting bytes that happen to look like percent-escapes or, if
+// they are invalid escapes, having the whole suffix silently dropped.
+func EscapePathSuffix(suffix string) string {
+	if suffix == "" {
+		return ""
+	}
+	trailingSlash := strings.HasSuffix(suffix, "/")
+	segments := strings.Split(strings.Trim(suffix, "/"), "/")
+	for i, seg := range segments {
+		segments[i] = url.PathEscape(seg)
+	}
+	out := "/" + strings.Join(segments, "/")
+	if trailingSlash && out != "/" {
+		out += "/"
+	}
+	return out
 }
 
 // Manifest represents user-supplied per-host manifest information.
@@ -91,49 +122,51 @@ func (m Mount) hostPathPrefix(rootPath string) string {
 func (m Mount) HostPath(rootPath, requestPath string) string {
 	suffix := m.Path
 	if m.AppendSuffix {
-		suffix = m.PathSuffix(requestPath)
+		if s, ok := m.PathSuffix(requestPath); ok {
+			suffix = s
+		} else {
+			suffix = ""
+		}
 	}
-	return filepath.Join(m.hostPathPrefix(rootPath), strings.TrimLeft(suffix, "/"))
+	return filepath.Join(m.hostPathPrefix(rootPath), suffix)
 }
 
 func (m Mount) ValidateHostPath(rootPath string, hostPath string) bool {
 	base := filepath.Clean(m.hostPathPrefix(rootPath))
 	target := filepath.Clean(hostPath)
 	rel, err := filepath.Rel(base, target)
-	if err != nil {
-		return false
-	}
-	if rel == ".." || strings.HasPrefix(filepath.ToSlash(rel), "../") {
-		return false
-	}
-	return true
+	return err == nil && filepath.IsLocal(rel)
 }
 
-// PathSuffix extracts the portion of requestPath that extends beyond the
-// mount's Path. Both paths are normalized before comparison so that
-// leading/trailing slashes do not affect the result. The returned suffix
-// always starts with "/" (or is empty when the paths are equal).
-// PathSuffix enforces segment-boundary matching: mount "foo" will not match
-// request "foobar".
-func (m Mount) PathSuffix(requestPath string) string {
-	nReq := normalizePath(requestPath)
-	nMount := normalizePath(m.Path)
-	if nMount == "" {
-		if nReq == "" {
-			return ""
-		}
-		return "/" + nReq
-	}
+// PathSuffix extracts the canonical portion of requestPath that extends
+// beyond the mount's Path, for callers that append it to a proxy target or
+// local directory (AppendSuffix). Both paths are cleaned via cleanPath
+// before comparison, using the same segment-boundary matching as GetMount,
+// so a suffix is only ever extracted from a request that GetMount would
+// have routed to this mount. ok is false when requestPath does not fall
+// under the mount's Path at a segment boundary; this should never happen
+// for a mount already selected by GetMount, since both use identical
+// matching rules. A trailing slash on requestPath is preserved on the
+// returned suffix so directory-style proxy requests are not truncated.
+func (m Mount) PathSuffix(requestPath string) (suffix string, ok bool) {
+	nReq, trailingSlash := cleanPath(requestPath)
+	nMount, _ := cleanPath(m.Path)
+
 	if !pathHasPrefix(nReq, nMount) {
-		// no segment-boundary prefix match — return the full request as-is
-		return "/" + nReq
+		return "", false
 	}
-	rest := strings.TrimPrefix(nReq, nMount)
+
+	rest := strings.TrimPrefix(strings.TrimPrefix(nReq, nMount), "/")
 	if rest == "" {
-		return ""
+		if trailingSlash {
+			return "/", true
+		}
+		return "", true
 	}
-	// rest always starts with "/" because pathHasPrefix guarantees segment-boundary matching
-	return rest
+	if trailingSlash {
+		rest += "/"
+	}
+	return "/" + rest, true
 }
 
 func (m Mount) ProxyDirector() (func(req *http.Request), error) {
@@ -160,25 +193,20 @@ func (m Mount) ProxyDirector() (func(req *http.Request), error) {
 		}
 
 		if m.AppendSuffix {
-			origPath := req.URL.Path
-			origRaw := req.URL.RawPath
-			if origRaw == "" {
-				origRaw = origPath
-			}
-
-			suffix := m.PathSuffix(origPath)
-			req.URL.Path = path.Join(target.Path, suffix)
-
-			targetRaw := target.RawPath
-			if targetRaw == "" {
-				targetRaw = target.Path
-			}
-
-			if target.RawPath != "" || req.URL.RawPath != "" {
-				rawSuffix := m.PathSuffix(origRaw)
-				req.URL.RawPath = path.Join(targetRaw, rawSuffix)
+			suffix, ok := m.PathSuffix(req.URL.Path)
+			if !ok || suffix == "" {
+				// A request for the mount's own root (or one that
+				// couldn't be matched, which shouldn't happen for a
+				// mount GetMount already selected) maps to the
+				// configured target verbatim. Going through JoinPath
+				// with an empty suffix would silently drop a trailing
+				// slash the operator configured on the target.
+				req.URL.Path = target.Path
+				req.URL.RawPath = target.RawPath
 			} else {
-				req.URL.RawPath = ""
+				joined := target.JoinPath(EscapePathSuffix(suffix))
+				req.URL.Path = joined.Path
+				req.URL.RawPath = joined.RawPath
 			}
 		} else {
 			req.URL.Path = target.Path
@@ -213,28 +241,27 @@ type ContentContext struct {
 
 // GetMount returns best matching Mount, respecting exact and prefix-based mount paths.
 // Longest path match is considered "best".
-// Both the request path and mount paths are normalized (leading/trailing slashes
-// stripped) before comparison. Prefix matches are checked at path-segment
-// boundaries so that mount "foo" does not match request "foobar".
+// Both the request path and mount paths are cleaned (via cleanPath) before
+// comparison, so leading/trailing slashes and "." / ".." segments do not
+// affect matching. Prefix matches are checked at path-segment boundaries so
+// that mount "foo" does not match request "foobar".
 func (m *Manifest) GetMount(reqPath string) (Mount, error) {
-	nPath := normalizePath(reqPath)
+	nPath, _ := cleanPath(reqPath)
 	var bestMount Mount
-	var bestLen int
-	var found bool
+	bestLen := -1
 	for _, mount := range m.Mounts {
-		nMountPath := normalizePath(mount.Path)
+		nMountPath, _ := cleanPath(mount.Path)
 		if !mount.PathIsPrefix && nMountPath == nPath {
 			return mount, nil
 		} else if mount.PathIsPrefix &&
 			pathHasPrefix(nPath, nMountPath) &&
-			(len(nMountPath) > bestLen || !found) {
+			len(nMountPath) > bestLen {
 			bestMount = mount
 			bestLen = len(nMountPath)
-			found = true
 		}
 	}
 
-	if found {
+	if bestLen >= 0 {
 		return bestMount, nil
 	}
 	return bestMount, errors.New("no mount matches path: " + reqPath)

--- a/manifest/schema.go
+++ b/manifest/schema.go
@@ -5,10 +5,32 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
 )
+
+// normalizePath strips leading and trailing slashes to produce a canonical
+// path for comparison. This ensures "/foo/bar", "foo/bar", and "foo/bar/"
+// are all treated identically.
+func normalizePath(p string) string {
+	return strings.Trim(p, "/")
+}
+
+// pathHasPrefix reports whether the normalized request path starts with the
+// normalized mount prefix at a path-segment boundary. An empty prefix matches
+// everything. This prevents "foo" from incorrectly matching "foobar".
+func pathHasPrefix(requestPath, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	if requestPath == prefix {
+		return true
+	}
+	// The request must continue with a "/" after the prefix.
+	return strings.HasPrefix(requestPath, prefix+"/")
+}
 
 // Manifest represents user-supplied per-host manifest information.
 // go-yaml accepts completely lowercase version of keys but is not case-insensitive
@@ -67,15 +89,42 @@ func (m Mount) hostPathPrefix(rootPath string) string {
 }
 
 func (m Mount) HostPath(rootPath, requestPath string) string {
-	path := m.Path
+	suffix := m.Path
 	if m.AppendSuffix {
-		path = strings.TrimPrefix(requestPath, m.Path)
+		suffix = m.PathSuffix(requestPath)
 	}
-	return filepath.Join(m.hostPathPrefix(rootPath), path)
+	return filepath.Join(m.hostPathPrefix(rootPath), suffix)
 }
 
 func (m Mount) ValidateHostPath(rootPath string, hostPath string) bool {
 	return strings.HasPrefix(hostPath, m.hostPathPrefix(rootPath))
+}
+
+// PathSuffix extracts the portion of requestPath that extends beyond the
+// mount's Path. Both paths are normalized before comparison so that
+// leading/trailing slashes do not affect the result. The returned suffix
+// always starts with "/" (or is empty when the paths are equal).
+// PathSuffix enforces segment-boundary matching: mount "foo" will not match
+// request "foobar".
+func (m Mount) PathSuffix(requestPath string) string {
+	nReq := normalizePath(requestPath)
+	nMount := normalizePath(m.Path)
+	if nMount == "" {
+		if nReq == "" {
+			return ""
+		}
+		return "/" + nReq
+	}
+	if !pathHasPrefix(nReq, nMount) {
+		// no segment-boundary prefix match — return the full request as-is
+		return "/" + nReq
+	}
+	rest := strings.TrimPrefix(nReq, nMount)
+	if rest == "" {
+		return ""
+	}
+	// rest always starts with "/" because pathHasPrefix guarantees segment-boundary matching
+	return rest
 }
 
 func (m Mount) ProxyDirector() (func(req *http.Request), error) {
@@ -102,8 +151,12 @@ func (m Mount) ProxyDirector() (func(req *http.Request), error) {
 		}
 
 		if m.AppendSuffix {
-			req.URL.Path = target.Path + strings.TrimPrefix(req.URL.Path, m.Path)
-			req.URL.RawPath = target.RawPath + strings.TrimPrefix(req.URL.RawPath, m.Path)
+			suffix := m.PathSuffix(req.URL.Path)
+			req.URL.Path = path.Join(target.Path, suffix)
+			if req.URL.RawPath != "" {
+				rawSuffix := m.PathSuffix(req.URL.RawPath)
+				req.URL.RawPath = path.Join(target.RawPath, rawSuffix)
+			}
 		} else {
 			req.URL.Path = target.Path
 			req.URL.RawPath = target.RawPath
@@ -137,19 +190,23 @@ type ContentContext struct {
 
 // GetMount returns best matching Mount, respecting exact and prefix-based mount paths.
 // Longest path match is considered "best".
-// If the path in the Mount or being matched begins with a slash (/), it is ignored.
-func (m *Manifest) GetMount(path string) (Mount, error) {
-	path = strings.TrimLeft(path, "/")
+// Both the request path and mount paths are normalized (leading/trailing slashes
+// stripped) before comparison. Prefix matches are checked at path-segment
+// boundaries so that mount "foo" does not match request "foobar".
+func (m *Manifest) GetMount(reqPath string) (Mount, error) {
+	nPath := normalizePath(reqPath)
 	var bestMount Mount
+	var bestLen int
 	var found bool
 	for _, mount := range m.Mounts {
-		mountPath := strings.TrimLeft(mount.Path, "/")
-		if !mount.PathIsPrefix && mountPath == path {
+		nMountPath := normalizePath(mount.Path)
+		if !mount.PathIsPrefix && nMountPath == nPath {
 			return mount, nil
 		} else if mount.PathIsPrefix &&
-			(mountPath == "" || strings.HasPrefix(path, mountPath)) &&
-			(len(mount.Path) > len(bestMount.Path) || !found) {
+			pathHasPrefix(nPath, nMountPath) &&
+			(len(nMountPath) > bestLen || !found) {
 			bestMount = mount
+			bestLen = len(nMountPath)
 			found = true
 		}
 	}
@@ -157,5 +214,5 @@ func (m *Manifest) GetMount(path string) (Mount, error) {
 	if found {
 		return bestMount, nil
 	}
-	return bestMount, errors.New("no mount matches path: " + path)
+	return bestMount, errors.New("no mount matches path: " + reqPath)
 }

--- a/manifest/schema.go
+++ b/manifest/schema.go
@@ -97,7 +97,16 @@ func (m Mount) HostPath(rootPath, requestPath string) string {
 }
 
 func (m Mount) ValidateHostPath(rootPath string, hostPath string) bool {
-	return strings.HasPrefix(hostPath, m.hostPathPrefix(rootPath))
+	base := filepath.Clean(m.hostPathPrefix(rootPath))
+	target := filepath.Clean(hostPath)
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(filepath.ToSlash(rel), "../") {
+		return false
+	}
+	return true
 }
 
 // PathSuffix extracts the portion of requestPath that extends beyond the

--- a/manifest/schema.go
+++ b/manifest/schema.go
@@ -93,7 +93,7 @@ func (m Mount) HostPath(rootPath, requestPath string) string {
 	if m.AppendSuffix {
 		suffix = m.PathSuffix(requestPath)
 	}
-	return filepath.Join(m.hostPathPrefix(rootPath), suffix)
+	return filepath.Join(m.hostPathPrefix(rootPath), strings.TrimLeft(suffix, "/"))
 }
 
 func (m Mount) ValidateHostPath(rootPath string, hostPath string) bool {
@@ -151,11 +151,25 @@ func (m Mount) ProxyDirector() (func(req *http.Request), error) {
 		}
 
 		if m.AppendSuffix {
-			suffix := m.PathSuffix(req.URL.Path)
+			origPath := req.URL.Path
+			origRaw := req.URL.RawPath
+			if origRaw == "" {
+				origRaw = origPath
+			}
+
+			suffix := m.PathSuffix(origPath)
 			req.URL.Path = path.Join(target.Path, suffix)
-			if req.URL.RawPath != "" {
-				rawSuffix := m.PathSuffix(req.URL.RawPath)
-				req.URL.RawPath = path.Join(target.RawPath, rawSuffix)
+
+			targetRaw := target.RawPath
+			if targetRaw == "" {
+				targetRaw = target.Path
+			}
+
+			if target.RawPath != "" || req.URL.RawPath != "" {
+				rawSuffix := m.PathSuffix(origRaw)
+				req.URL.RawPath = path.Join(targetRaw, rawSuffix)
+			} else {
+				req.URL.RawPath = ""
 			}
 		} else {
 			req.URL.Path = target.Path

--- a/manifest/schema_test.go
+++ b/manifest/schema_test.go
@@ -2,30 +2,38 @@ package manifest
 
 import (
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 )
 
-func TestNormalizePath(t *testing.T) {
+func TestCleanPath(t *testing.T) {
 	tests := []struct {
-		name string
-		in   string
-		want string
+		name         string
+		in           string
+		want         string
+		wantTrailing bool
 	}{
-		{"empty", "", ""},
-		{"slash only", "/", ""},
-		{"trailing slash", "foo/", "foo"},
-		{"leading slash", "/foo", "foo"},
-		{"both slashes", "/foo/", "foo"},
-		{"multiple leading", "///foo", "foo"},
-		{"nested", "/foo/bar/baz", "foo/bar/baz"},
-		{"nested trailing", "/foo/bar/", "foo/bar"},
-		{"no slashes", "foo/bar", "foo/bar"},
+		{"empty", "", "", false},
+		{"slash only", "/", "", false},
+		{"trailing slash", "foo/", "foo", true},
+		{"leading slash", "/foo", "foo", false},
+		{"both slashes", "/foo/", "foo", true},
+		{"multiple leading", "///foo", "foo", false},
+		{"nested", "/foo/bar/baz", "foo/bar/baz", false},
+		{"nested trailing", "/foo/bar/", "foo/bar", true},
+		{"no slashes", "foo/bar", "foo/bar", false},
+		{"interior double slash", "/foo//bar", "foo/bar", false},
+		{"dot segment", "/foo/./bar", "foo/bar", false},
+		{"dot-dot climbs to root", "/foo/../bar", "bar", false},
+		{"dot-dot cannot escape root", "/../../secret", "secret", false},
+		{"dot-dot with trailing slash", "/foo/../bar/", "bar", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := normalizePath(tt.in)
-			if got != tt.want {
-				t.Errorf("normalizePath(%q) = %q, want %q", tt.in, got, tt.want)
+			got, gotTrailing := cleanPath(tt.in)
+			if got != tt.want || gotTrailing != tt.wantTrailing {
+				t.Errorf("cleanPath(%q) = (%q, %v), want (%q, %v)", tt.in, got, gotTrailing, tt.want, tt.wantTrailing)
 			}
 		})
 	}
@@ -154,26 +162,55 @@ func TestPathSuffix(t *testing.T) {
 		mountPath string
 		reqPath   string
 		want      string
+		wantOK    bool
 	}{
-		{"exact match", "/foo", "/foo", ""},
-		{"exact match no slashes", "foo", "foo", ""},
-		{"suffix extraction", "/foo", "/foo/bar", "/bar"},
-		{"mismatched leading slashes", "foo", "/foo/bar", "/bar"},
-		{"mount with slash request without", "/foo", "foo/bar/baz", "/bar/baz"},
-		{"trailing slash on mount", "foo/", "/foo/bar", "/bar"},
-		{"empty mount", "", "/foo/bar", "/foo/bar"},
-		{"empty mount empty request", "", "", ""},
-		{"deep suffix", "/a/b", "/a/b/c/d/e", "/c/d/e"},
-		{"partial segment no match", "foo", "foobar", "/foobar"},
-		{"partial segment nested no match", "foo/bar", "foo/barbaz", "/foo/barbaz"},
+		{"exact match", "/foo", "/foo", "", true},
+		{"exact match no slashes", "foo", "foo", "", true},
+		{"suffix extraction", "/foo", "/foo/bar", "/bar", true},
+		{"mismatched leading slashes", "foo", "/foo/bar", "/bar", true},
+		{"mount with slash request without", "/foo", "foo/bar/baz", "/bar/baz", true},
+		{"trailing slash on mount", "foo/", "/foo/bar", "/bar", true},
+		{"empty mount", "", "/foo/bar", "/foo/bar", true},
+		{"empty mount empty request", "", "", "", true},
+		{"deep suffix", "/a/b", "/a/b/c/d/e", "/c/d/e", true},
+		{"partial segment no match", "foo", "foobar", "", false},
+		{"partial segment nested no match", "foo/bar", "foo/barbaz", "", false},
+		{"trailing slash preserved", "/foo", "/foo/bar/", "/bar/", true},
+		{"trailing slash preserved at mount root", "/foo", "/foo/", "/", true},
+		{"dot-dot cannot escape mount", "/foo", "/foo/../../secret", "", false},
+		{"dot-dot within mount resolves", "/foo", "/foo/bar/../baz", "/baz", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := Mount{Path: tt.mountPath}
-			got := m.PathSuffix(tt.reqPath)
+			got, ok := m.PathSuffix(tt.reqPath)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("Mount{Path: %q}.PathSuffix(%q) = (%q, %v), want (%q, %v)",
+					tt.mountPath, tt.reqPath, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestEscapePathSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"simple", "/bar", "/bar"},
+		{"trailing slash", "/bar/", "/bar/"},
+		{"root trailing slash", "/", "/"},
+		{"space needs escaping", "/a b", "/a%20b"},
+		{"literal percent is escaped, not misread", "/100%off", "/100%25off"},
+		{"literal slash-looking escape stays literal", "/a%2Fb", "/a%252Fb"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EscapePathSuffix(tt.in)
 			if got != tt.want {
-				t.Errorf("Mount{Path: %q}.PathSuffix(%q) = %q, want %q",
-					tt.mountPath, tt.reqPath, got, tt.want)
+				t.Errorf("EscapePathSuffix(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}
@@ -275,16 +312,22 @@ func TestProxyDirector_Escaping(t *testing.T) {
 			wantEscaped: "/repo%2Fsub/ubuntu/file.iso",
 		},
 		{
+			// Matching and suffix extraction operate on the decoded request
+			// path (same as GetMount), so a %2F in the request is treated as
+			// a literal path separator rather than round-tripped verbatim.
+			// This trades exact-byte preservation for a suffix that can
+			// never desync Path from RawPath (see the RawPath-consistency
+			// tests below).
 			name:        "target has no escaping, request has escaped path",
 			mount:       Mount{Path: "/images", Proxy: "http://upstream/repo", PathIsPrefix: true, AppendSuffix: true},
 			reqURL:      "http://localhost/images/ubuntu%2Ffile.iso",
-			wantEscaped: "/repo/ubuntu%2Ffile.iso",
+			wantEscaped: "/repo/ubuntu/file.iso",
 		},
 		{
 			name:        "both target and request have escaped paths",
 			mount:       Mount{Path: "/images", Proxy: "http://upstream/repo%2Fsub", PathIsPrefix: true, AppendSuffix: true},
 			reqURL:      "http://localhost/images/ubuntu%2Ffile.iso",
-			wantEscaped: "/repo%2Fsub/ubuntu%2Ffile.iso",
+			wantEscaped: "/repo%2Fsub/ubuntu/file.iso",
 		},
 		{
 			name:        "neither has escaping",
@@ -309,6 +352,108 @@ func TestProxyDirector_Escaping(t *testing.T) {
 				t.Errorf("after director, URL.EscapedPath() = %q, want %q", got, tt.wantEscaped)
 			}
 		})
+	}
+}
+
+func TestProxyDirector_TrailingSlashPreserved(t *testing.T) {
+	// A directory-style request (trailing slash) must proxy to a
+	// directory-style upstream URL, not have the slash silently dropped.
+	mount := Mount{Path: "/", PathIsPrefix: true, AppendSuffix: true,
+		Proxy: "http://upstream/dists/focal/netboot/amd64/"}
+	director, err := mount.ProxyDirector()
+	if err != nil {
+		t.Fatalf("ProxyDirector() error: %v", err)
+	}
+
+	tests := []struct {
+		reqPath  string
+		wantPath string
+	}{
+		{"/", "/dists/focal/netboot/amd64/"},
+		{"/subdir/", "/dists/focal/netboot/amd64/subdir/"},
+		{"/subdir", "/dists/focal/netboot/amd64/subdir"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.reqPath, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "http://localhost"+tt.reqPath, nil)
+			director(req)
+			if req.URL.Path != tt.wantPath {
+				t.Errorf("director(%q): Path = %q, want %q", tt.reqPath, req.URL.Path, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestProxyDirector_DotDotCannotEscapeTarget(t *testing.T) {
+	mount := Mount{Path: "/images", PathIsPrefix: true, AppendSuffix: true,
+		Proxy: "http://upstream/repo/"}
+	director, err := mount.ProxyDirector()
+	if err != nil {
+		t.Fatalf("ProxyDirector() error: %v", err)
+	}
+	req, _ := http.NewRequest("GET", "http://localhost/images/../../secret", nil)
+	director(req)
+	if !strings.HasPrefix(req.URL.Path, "/repo/") {
+		t.Errorf("dot-dot request escaped proxy base: Path = %q", req.URL.Path)
+	}
+}
+
+func TestProxyDirector_RawPathAlwaysConsistent(t *testing.T) {
+	// Path and RawPath must always describe the same resource, or the
+	// server silently sends whichever one it recomputes rather than what
+	// was configured/requested.
+	mount := Mount{Path: "/images", PathIsPrefix: true, AppendSuffix: true,
+		Proxy: "http://upstream/repo%2Fsub"}
+	director, err := mount.ProxyDirector()
+	if err != nil {
+		t.Fatalf("ProxyDirector() error: %v", err)
+	}
+
+	// Unlike TFTP filenames, a malformed percent-escape (e.g. "100%off")
+	// never reaches the director for HTTP requests: net/http rejects it
+	// while parsing the request line, before routing. That case is covered
+	// for TFTP by TestTftpProxySuffix_InvalidEscapeIsSafe instead.
+	reqPaths := []string{
+		"/images/a b/file.iso",
+		"/images/ubuntu%2Ffile.iso/x",
+		"/images/../top",
+	}
+	for _, p := range reqPaths {
+		t.Run(p, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "http://localhost"+p, nil)
+			if err != nil {
+				t.Fatalf("NewRequest() error: %v", err)
+			}
+			director(req)
+			if req.URL.RawPath != "" {
+				unescaped, err := url.PathUnescape(req.URL.RawPath)
+				if err != nil {
+					t.Fatalf("RawPath %q is not validly escaped: %v", req.URL.RawPath, err)
+				}
+				if unescaped != req.URL.Path {
+					t.Errorf("RawPath %q does not decode to Path %q (decoded to %q)",
+						req.URL.RawPath, req.URL.Path, unescaped)
+				}
+			}
+		})
+	}
+}
+
+func TestTftpProxySuffix_InvalidEscapeIsSafe(t *testing.T) {
+	// A TFTP filename containing a literal '%' that isn't a valid escape
+	// must not be silently dropped by url.JoinPath.
+	mount := Mount{Path: "/images", PathIsPrefix: true, AppendSuffix: true}
+	suffix, ok := mount.PathSuffix("images/100%off/file")
+	if !ok {
+		t.Fatalf("PathSuffix() ok = false, want true")
+	}
+	got, err := url.JoinPath("http://upstream/repo", EscapePathSuffix(suffix))
+	if err != nil {
+		t.Fatalf("JoinPath() error: %v", err)
+	}
+	want := "http://upstream/repo/100%25off/file"
+	if got != want {
+		t.Errorf("JoinPath() = %q, want %q", got, want)
 	}
 }
 

--- a/manifest/schema_test.go
+++ b/manifest/schema_test.go
@@ -261,6 +261,57 @@ func TestProxyDirector_AppendSuffix(t *testing.T) {
 	}
 }
 
+func TestProxyDirector_Escaping(t *testing.T) {
+	tests := []struct {
+		name        string
+		mount       Mount
+		reqURL      string
+		wantEscaped string
+	}{
+		{
+			name:        "target has escaped path, request has no escaping",
+			mount:       Mount{Path: "/images", Proxy: "http://upstream/repo%2Fsub", PathIsPrefix: true, AppendSuffix: true},
+			reqURL:      "http://localhost/images/ubuntu/file.iso",
+			wantEscaped: "/repo%2Fsub/ubuntu/file.iso",
+		},
+		{
+			name:        "target has no escaping, request has escaped path",
+			mount:       Mount{Path: "/images", Proxy: "http://upstream/repo", PathIsPrefix: true, AppendSuffix: true},
+			reqURL:      "http://localhost/images/ubuntu%2Ffile.iso",
+			wantEscaped: "/repo/ubuntu%2Ffile.iso",
+		},
+		{
+			name:        "both target and request have escaped paths",
+			mount:       Mount{Path: "/images", Proxy: "http://upstream/repo%2Fsub", PathIsPrefix: true, AppendSuffix: true},
+			reqURL:      "http://localhost/images/ubuntu%2Ffile.iso",
+			wantEscaped: "/repo%2Fsub/ubuntu%2Ffile.iso",
+		},
+		{
+			name:        "neither has escaping",
+			mount:       Mount{Path: "/images", Proxy: "http://upstream/repo", PathIsPrefix: true, AppendSuffix: true},
+			reqURL:      "http://localhost/images/ubuntu/file.iso",
+			wantEscaped: "/repo/ubuntu/file.iso",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			director, err := tt.mount.ProxyDirector()
+			if err != nil {
+				t.Fatalf("ProxyDirector() error: %v", err)
+			}
+			req, err := http.NewRequest("GET", tt.reqURL, nil)
+			if err != nil {
+				t.Fatalf("NewRequest() error: %v", err)
+			}
+			director(req)
+			got := req.URL.EscapedPath()
+			if got != tt.wantEscaped {
+				t.Errorf("after director, URL.EscapedPath() = %q, want %q", got, tt.wantEscaped)
+			}
+		})
+	}
+}
+
 func TestGetMount_SlashVariations(t *testing.T) {
 	// Ensure all slash variations of the same mount path and request path match correctly.
 	pathVariations := []string{"/ubuntu", "ubuntu", "ubuntu/", "/ubuntu/"}

--- a/manifest/schema_test.go
+++ b/manifest/schema_test.go
@@ -181,40 +181,40 @@ func TestPathSuffix(t *testing.T) {
 
 func TestHostPath(t *testing.T) {
 	tests := []struct {
-		name         string
-		mount        Mount
-		rootPath     string
-		requestPath  string
-		wantContains string
+		name        string
+		mount       Mount
+		rootPath    string
+		requestPath string
+		want        string
 	}{
 		{
-			name:         "append suffix with slash mismatch",
-			mount:        Mount{Path: "/subdir", AppendSuffix: true, LocalDir: "/tftpboot"},
-			rootPath:     "/root",
-			requestPath:  "/subdir/file.x",
-			wantContains: "/tftpboot/file.x",
+			name:        "append suffix with slash mismatch",
+			mount:       Mount{Path: "/subdir", AppendSuffix: true, LocalDir: "/tftpboot"},
+			rootPath:    "/root",
+			requestPath: "/subdir/file.x",
+			want:        "/tftpboot/file.x",
 		},
 		{
-			name:         "append suffix without leading slash",
-			mount:        Mount{Path: "subdir", AppendSuffix: true, LocalDir: "/tftpboot"},
-			rootPath:     "/root",
-			requestPath:  "/subdir/file.x",
-			wantContains: "/tftpboot/file.x",
+			name:        "append suffix without leading slash",
+			mount:       Mount{Path: "subdir", AppendSuffix: true, LocalDir: "/tftpboot"},
+			rootPath:    "/root",
+			requestPath: "/subdir/file.x",
+			want:        "/tftpboot/file.x",
 		},
 		{
-			name:         "no append suffix",
-			mount:        Mount{Path: "/subdir", AppendSuffix: false, LocalDir: "/tftpboot"},
-			rootPath:     "/root",
-			requestPath:  "/subdir/file.x",
-			wantContains: "/tftpboot/subdir",
+			name:        "no append suffix",
+			mount:       Mount{Path: "/subdir", AppendSuffix: false, LocalDir: "/tftpboot"},
+			rootPath:    "/root",
+			requestPath: "/subdir/file.x",
+			want:        "/tftpboot/subdir",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.mount.HostPath(tt.rootPath, tt.requestPath)
-			if got != tt.wantContains {
+			if got != tt.want {
 				t.Errorf("HostPath(%q, %q) = %q, want %q",
-					tt.rootPath, tt.requestPath, got, tt.wantContains)
+					tt.rootPath, tt.requestPath, got, tt.want)
 			}
 		})
 	}

--- a/manifest/schema_test.go
+++ b/manifest/schema_test.go
@@ -1,0 +1,283 @@
+package manifest
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"slash only", "/", ""},
+		{"trailing slash", "foo/", "foo"},
+		{"leading slash", "/foo", "foo"},
+		{"both slashes", "/foo/", "foo"},
+		{"multiple leading", "///foo", "foo"},
+		{"nested", "/foo/bar/baz", "foo/bar/baz"},
+		{"nested trailing", "/foo/bar/", "foo/bar"},
+		{"no slashes", "foo/bar", "foo/bar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizePath(tt.in)
+			if got != tt.want {
+				t.Errorf("normalizePath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPathHasPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		reqPath string
+		prefix  string
+		want    bool
+	}{
+		{"empty prefix matches anything", "foo/bar", "", true},
+		{"exact match", "foo/bar", "foo/bar", true},
+		{"proper prefix", "foo/bar/baz", "foo/bar", true},
+		{"partial segment no match", "foobar", "foo", false},
+		{"partial segment nested no match", "foo/barbaz", "foo/bar", false},
+		{"prefix is longer", "foo", "foo/bar", false},
+		{"empty request empty prefix", "", "", true},
+		{"empty request nonempty prefix", "", "foo", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pathHasPrefix(tt.reqPath, tt.prefix)
+			if got != tt.want {
+				t.Errorf("pathHasPrefix(%q, %q) = %v, want %v", tt.reqPath, tt.prefix, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMount_ExactMatch(t *testing.T) {
+	m := &Manifest{
+		Mounts: []Mount{
+			{Path: "/foo/bar"},
+			{Path: "baz"},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		reqPath string
+		want    string
+		wantErr bool
+	}{
+		{"with leading slash", "/foo/bar", "/foo/bar", false},
+		{"without leading slash", "foo/bar", "/foo/bar", false},
+		{"trailing slash", "/foo/bar/", "/foo/bar", false},
+		{"no slashes", "baz", "baz", false},
+		{"leading slash on config without", "/baz", "baz", false},
+		{"no match", "/nonexistent", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mount, err := m.GetMount(tt.reqPath)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("GetMount(%q) error = %v, wantErr %v", tt.reqPath, err, tt.wantErr)
+			}
+			if !tt.wantErr && mount.Path != tt.want {
+				t.Errorf("GetMount(%q).Path = %q, want %q", tt.reqPath, mount.Path, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMount_PrefixMatch(t *testing.T) {
+	m := &Manifest{
+		Mounts: []Mount{
+			{Path: "/images", PathIsPrefix: true},
+			{Path: "/images/ubuntu", PathIsPrefix: true},
+			{Path: "/", PathIsPrefix: true},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		reqPath string
+		want    string
+	}{
+		{"root matches catch-all", "/somefile", "/"},
+		{"images prefix", "/images/file.iso", "/images"},
+		{"images/ubuntu more specific", "/images/ubuntu/file.iso", "/images/ubuntu"},
+		{"images exact", "/images", "/images"},
+		// Boundary check: "/imagesx" should NOT match "/images"
+		{"no partial segment match", "/imagesx/file", "/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mount, err := m.GetMount(tt.reqPath)
+			if err != nil {
+				t.Fatalf("GetMount(%q) unexpected error: %v", tt.reqPath, err)
+			}
+			if mount.Path != tt.want {
+				t.Errorf("GetMount(%q).Path = %q, want %q", tt.reqPath, mount.Path, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMount_PrefixBoundary(t *testing.T) {
+	// Ensure mount "foo" does NOT match request "foobar"
+	m := &Manifest{
+		Mounts: []Mount{
+			{Path: "foo", PathIsPrefix: true},
+		},
+	}
+
+	_, err := m.GetMount("foobar")
+	if err == nil {
+		t.Error("GetMount(\"foobar\") should not match mount \"foo\"")
+	}
+
+	// But "foo/bar" should match
+	mount, err := m.GetMount("foo/bar")
+	if err != nil {
+		t.Fatalf("GetMount(\"foo/bar\") unexpected error: %v", err)
+	}
+	if mount.Path != "foo" {
+		t.Errorf("GetMount(\"foo/bar\").Path = %q, want \"foo\"", mount.Path)
+	}
+}
+
+func TestPathSuffix(t *testing.T) {
+	tests := []struct {
+		name      string
+		mountPath string
+		reqPath   string
+		want      string
+	}{
+		{"exact match", "/foo", "/foo", ""},
+		{"exact match no slashes", "foo", "foo", ""},
+		{"suffix extraction", "/foo", "/foo/bar", "/bar"},
+		{"mismatched leading slashes", "foo", "/foo/bar", "/bar"},
+		{"mount with slash request without", "/foo", "foo/bar/baz", "/bar/baz"},
+		{"trailing slash on mount", "foo/", "/foo/bar", "/bar"},
+		{"empty mount", "", "/foo/bar", "/foo/bar"},
+		{"empty mount empty request", "", "", ""},
+		{"deep suffix", "/a/b", "/a/b/c/d/e", "/c/d/e"},
+		{"partial segment no match", "foo", "foobar", "/foobar"},
+		{"partial segment nested no match", "foo/bar", "foo/barbaz", "/foo/barbaz"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Mount{Path: tt.mountPath}
+			got := m.PathSuffix(tt.reqPath)
+			if got != tt.want {
+				t.Errorf("Mount{Path: %q}.PathSuffix(%q) = %q, want %q",
+					tt.mountPath, tt.reqPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		mount        Mount
+		rootPath     string
+		requestPath  string
+		wantContains string
+	}{
+		{
+			name:         "append suffix with slash mismatch",
+			mount:        Mount{Path: "/subdir", AppendSuffix: true, LocalDir: "/tftpboot"},
+			rootPath:     "/root",
+			requestPath:  "/subdir/file.x",
+			wantContains: "/tftpboot/file.x",
+		},
+		{
+			name:         "append suffix without leading slash",
+			mount:        Mount{Path: "subdir", AppendSuffix: true, LocalDir: "/tftpboot"},
+			rootPath:     "/root",
+			requestPath:  "/subdir/file.x",
+			wantContains: "/tftpboot/file.x",
+		},
+		{
+			name:         "no append suffix",
+			mount:        Mount{Path: "/subdir", AppendSuffix: false, LocalDir: "/tftpboot"},
+			rootPath:     "/root",
+			requestPath:  "/subdir/file.x",
+			wantContains: "/tftpboot/subdir",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.mount.HostPath(tt.rootPath, tt.requestPath)
+			if got != tt.wantContains {
+				t.Errorf("HostPath(%q, %q) = %q, want %q",
+					tt.rootPath, tt.requestPath, got, tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestProxyDirector_AppendSuffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		mount    Mount
+		reqPath  string
+		wantPath string
+	}{
+		{
+			name:     "suffix with matching slashes",
+			mount:    Mount{Path: "/images", Proxy: "http://upstream/repo", PathIsPrefix: true, AppendSuffix: true},
+			reqPath:  "/images/ubuntu/file.iso",
+			wantPath: "/repo/ubuntu/file.iso",
+		},
+		{
+			name:     "suffix with mismatched slashes",
+			mount:    Mount{Path: "images", Proxy: "http://upstream/repo/", PathIsPrefix: true, AppendSuffix: true},
+			reqPath:  "/images/ubuntu/file.iso",
+			wantPath: "/repo/ubuntu/file.iso",
+		},
+		{
+			name:     "no suffix",
+			mount:    Mount{Path: "/images", Proxy: "http://upstream/repo", PathIsPrefix: true, AppendSuffix: false},
+			reqPath:  "/images/ubuntu/file.iso",
+			wantPath: "/repo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			director, err := tt.mount.ProxyDirector()
+			if err != nil {
+				t.Fatalf("ProxyDirector() error: %v", err)
+			}
+			req, _ := http.NewRequest("GET", "http://localhost"+tt.reqPath, nil)
+			director(req)
+			if req.URL.Path != tt.wantPath {
+				t.Errorf("after director, URL.Path = %q, want %q", req.URL.Path, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestGetMount_SlashVariations(t *testing.T) {
+	// Ensure all slash variations of the same mount path and request path match correctly.
+	pathVariations := []string{"/ubuntu", "ubuntu", "ubuntu/", "/ubuntu/"}
+	for _, mountPath := range pathVariations {
+		m := &Manifest{
+			Mounts: []Mount{
+				{Path: mountPath},
+			},
+		}
+		for _, reqPath := range pathVariations {
+			t.Run(mountPath+"_vs_"+reqPath, func(t *testing.T) {
+				_, err := m.GetMount(reqPath)
+				if err != nil {
+					t.Errorf("GetMount(%q) with mount.Path=%q should match, got error: %v",
+						reqPath, mountPath, err)
+				}
+			})
+		}
+	}
+}

--- a/manifest/schema_test.go
+++ b/manifest/schema_test.go
@@ -257,6 +257,33 @@ func TestHostPath(t *testing.T) {
 	}
 }
 
+func TestValidateHostPath(t *testing.T) {
+	mount := Mount{Path: "/subdir", AppendSuffix: true, LocalDir: "/tftpboot"}
+	rootPath := "/root"
+
+	tests := []struct {
+		name     string
+		hostPath string
+		want     bool
+	}{
+		{"file within base", "/tftpboot/file.x", true},
+		{"nested file within base", "/tftpboot/sub/file.x", true},
+		{"base itself", "/tftpboot", true},
+		{"traversal out of base", "/tftpboot/../file.x", false},
+		{"traversal out of base via constructed path", "/tftpboot/../etc/passwd", false},
+		{"sibling directory sharing prefix", "/tftpboot2/file.x", false},
+		{"unrelated absolute path", "/etc/passwd", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mount.ValidateHostPath(rootPath, tt.hostPath)
+			if got != tt.want {
+				t.Errorf("ValidateHostPath(%q, %q) = %v, want %v", rootPath, tt.hostPath, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestProxyDirector_AppendSuffix(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/tftpd/handler.go
+++ b/tftpd/handler.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"text/template"
 
 	mfest "github.com/DSpeichert/netbootd/manifest"
@@ -67,12 +66,19 @@ func (server *Server) tftpReadHandler(filename string, rf io.ReaderFrom) error {
 		Msg("found mount")
 
 	if mount.Proxy != "" {
-		url := mount.Proxy
+		proxyURL := mount.Proxy
 		if mount.AppendSuffix {
-			url = url + strings.TrimPrefix(filename, mount.Path)
+			var err error
+			proxyURL, err = url.JoinPath(proxyURL, mount.PathSuffix(filename))
+			if err != nil {
+				server.logger.Error().
+					Err(err).
+					Msg("failed to build proxy URL")
+				return err
+			}
 		}
 
-		req, err := http.NewRequest("GET", url, nil)
+		req, err := http.NewRequest("GET", proxyURL, nil)
 		if err != nil {
 			server.logger.Error().
 				Err(err).
@@ -93,7 +99,7 @@ func (server *Server) tftpReadHandler(filename string, rf io.ReaderFrom) error {
 
 		if resp.StatusCode == http.StatusNotFound {
 			server.logger.Error().
-				Str("url", url).
+				Str("url", proxyURL).
 				Str("status", resp.Status).
 				Str("path", filename).
 				Str("client", raddr.IP.String()).
@@ -120,7 +126,7 @@ func (server *Server) tftpReadHandler(filename string, rf io.ReaderFrom) error {
 		server.logger.Info().
 			Err(err).
 			Str("path", filename).
-			Str("url", url).
+			Str("url", proxyURL).
 			Str("client", raddr.IP.String()).
 			Int64("sent", n).
 			Msg("transfer finished")
@@ -140,13 +146,13 @@ func (server *Server) tftpReadHandler(filename string, rf io.ReaderFrom) error {
 			RemoteIP: raddr.IP,
 			HttpBaseUrl: &url.URL{
 				Scheme: "http",
-				Host:   net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.GlobalHints.HttpPort)),
+				Host:   net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.HTTPPort())),
 			},
 			ApiBaseUrl: &url.URL{
 				Scheme: "http",
-				Host:   net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.GlobalHints.ApiPort)),
+				Host:   net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.APIPort())),
 			},
-			SyslogHost: net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.GlobalHints.SyslogPort)),
+			SyslogHost: net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.SyslogPort())),
 			Manifest:   manifest,
 		})
 		if err != nil {

--- a/tftpd/handler.go
+++ b/tftpd/handler.go
@@ -68,8 +68,13 @@ func (server *Server) tftpReadHandler(filename string, rf io.ReaderFrom) error {
 	if mount.Proxy != "" {
 		proxyURL := mount.Proxy
 		if mount.AppendSuffix {
+			suffix, ok := mount.PathSuffix(filename)
+			if !ok {
+				suffix = ""
+			}
+
 			var err error
-			proxyURL, err = url.JoinPath(proxyURL, mount.PathSuffix(filename))
+			proxyURL, err = url.JoinPath(proxyURL, mfest.EscapePathSuffix(suffix))
 			if err != nil {
 				server.logger.Error().
 					Err(err).

--- a/tftpd/handler.go
+++ b/tftpd/handler.go
@@ -146,13 +146,13 @@ func (server *Server) tftpReadHandler(filename string, rf io.ReaderFrom) error {
 			RemoteIP: raddr.IP,
 			HttpBaseUrl: &url.URL{
 				Scheme: "http",
-				Host:   net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.HTTPPort())),
+				Host:   net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.GlobalHints.HttpPort)),
 			},
 			ApiBaseUrl: &url.URL{
 				Scheme: "http",
-				Host:   net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.APIPort())),
+				Host:   net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.GlobalHints.ApiPort)),
 			},
-			SyslogHost: net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.SyslogPort())),
+			SyslogHost: net.JoinHostPort(laddr.String(), strconv.Itoa(server.store.GlobalHints.SyslogPort)),
 			Manifest:   manifest,
 		})
 		if err != nil {

--- a/tftpd/handler.go
+++ b/tftpd/handler.go
@@ -70,16 +70,22 @@ func (server *Server) tftpReadHandler(filename string, rf io.ReaderFrom) error {
 		if mount.AppendSuffix {
 			suffix, ok := mount.PathSuffix(filename)
 			if !ok {
+				server.logger.Warn().
+					Str("path", filename).
+					Interface("mount", mount).
+					Msg("PathSuffix could not match a mount already selected by GetMount")
 				suffix = ""
 			}
 
-			var err error
-			proxyURL, err = url.JoinPath(proxyURL, mfest.EscapePathSuffix(suffix))
-			if err != nil {
-				server.logger.Error().
-					Err(err).
-					Msg("failed to build proxy URL")
-				return err
+			if suffix != "" {
+				var err error
+				proxyURL, err = url.JoinPath(proxyURL, mfest.EscapePathSuffix(suffix))
+				if err != nil {
+					server.logger.Error().
+						Err(err).
+						Msg("failed to build proxy URL")
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

Path normalization was inconsistent across the TFTP and HTTP servers. Leading/trailing slashes on mount paths vs request paths caused `strings.TrimPrefix` to silently fail (returning the full string unchanged), breaking `pathIsPrefix` + `appendSuffix` functionality.

Additionally, `GetMount`'s prefix matching used raw `strings.HasPrefix`, which incorrectly matched partial path segments (e.g., mount `foo` would match request `foobar`).

## Changes

### `manifest/schema.go`
- Add `normalizePath()` — strips leading/trailing slashes for canonical comparison
- Add `pathHasPrefix()` — segment-boundary-aware prefix check (prevents mount `foo` from matching request `foobar`)
- Add `Mount.PathSuffix()` — exported method to extract suffix using normalized comparison
- Fix `GetMount` to use normalized paths and boundary-aware prefix checks
- Fix `HostPath` to use `PathSuffix` instead of raw `TrimPrefix`
- Fix `ProxyDirector` to use `PathSuffix` with `path.Join` for clean URL construction

### `tftpd/handler.go`
- Fix proxy URL suffix extraction to use `mount.PathSuffix(filename)` instead of `strings.TrimPrefix`
- Remove unused `strings` import

### `manifest/schema_test.go` (new)
- 53 table-driven test cases covering:
  - `normalizePath` edge cases
  - `pathHasPrefix` segment-boundary enforcement
  - `GetMount` exact, prefix, and boundary matching
  - `PathSuffix` with all slash variations
  - `HostPath` with `appendSuffix` and slash mismatches
  - `ProxyDirector` URL construction
  - Cross-product of slash variations for mount/request paths